### PR TITLE
feat: remove CommonJS (.cjs) and CommonTS (.cts) file extensions from Jest config

### DIFF
--- a/__tests__/integration.test.ts
+++ b/__tests__/integration.test.ts
@@ -16,10 +16,7 @@ test("INTEGRATION: ensure that the original src/ files are mapped one-to-one wit
 				// Filter the item _in_ as a file if:
 				(item) =>
 					// 1. It *does* end with one of the following file extensions; and
-					(item.endsWith(".cjs") ||
-						item.endsWith(".cts") ||
-						item.endsWith(".js") ||
-						item.endsWith(".ts")) &&
+					(item.endsWith(".js") || item.endsWith(".ts")) &&
 					// 2. It *does not* contain the ".mock" or ".test" substrings.
 					!(item.includes(".mock") || item.includes(".test")),
 			)
@@ -29,12 +26,6 @@ test("INTEGRATION: ensure that the original src/ files are mapped one-to-one wit
 			.map((file) => {
 				let fileWithoutExtension = "";
 
-				if (file.endsWith(".cjs")) {
-					fileWithoutExtension = file.replace(".cjs", "");
-				}
-				if (file.endsWith(".cts")) {
-					fileWithoutExtension = file.replace(".cts", "");
-				}
 				if (file.endsWith(".js")) {
 					fileWithoutExtension = file.replace(".js", "");
 				}

--- a/src/jest.config.ts
+++ b/src/jest.config.ts
@@ -35,8 +35,6 @@ export const makeJestConfig = async (): Promise<Config> => {
 		: // If running tests on a `consuming-repo`, set the path relative to its `devdeps` dependency.
 			(`<rootDir>/${dependencyPartialPath}` as const);
 
-	// Note: The `cjs` and `cts` file extensions are included in the Jest config because this repo has some tools
-	// that only work with CommonJS `module.exports = {}` objects, and these files need to be unit tested too.
 	return {
 		// Excerpt from https://jestjs.io/docs/configuration#cachedirectory-string:
 		// > The directory where Jest should store its cached dependency information.
@@ -48,7 +46,7 @@ export const makeJestConfig = async (): Promise<Config> => {
 		// > An array of glob patterns indicating a set of files for which coverage information should be collected.
 		// > If a file matches the specified glob pattern, coverage information will be collected for it even if
 		// > no tests exist for this file and it's never required in the test suite.
-		collectCoverageFrom: ["**/*.{cjs,js,jsx,cts,ts,tsx}"],
+		collectCoverageFrom: ["**/*.{js,jsx,ts,tsx}"],
 		// https://stackoverflow.com/questions/69567201/coveragepathignorepatterns-ignore-files-with-specific-ending
 		coveragePathIgnorePatterns: [
 			...ignorePatterns,
@@ -74,7 +72,7 @@ export const makeJestConfig = async (): Promise<Config> => {
 		// Excerpt from https://jestjs.io/docs/configuration#modulefileextensions-arraystring:
 		// > We recommend placing the extensions most commonly used in your project on the left, so if you are
 		// > using TypeScript, you may want to consider moving "ts" and/or "tsx" to the beginning of the array.
-		moduleFileExtensions: ["cts", "ts", "tsx", "cjs", "js", "jsx", "json"],
+		moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json"],
 		// TypeScript knows how to map imported files with the ".js" extension to their ".ts" counterparts. Jest
 		// doesn't handle this automatically, so specify `moduleNameMapper` to handle `.js` and `.jsx` file extensions.
 		// Excerpt from https://jestjs.io/docs/configuration#modulenamemapper-objectstring-string--arraystring:
@@ -82,7 +80,7 @@ export const makeJestConfig = async (): Promise<Config> => {
 		// > allow to stub out resources, like images or styles with a single module.
 		moduleNameMapper: {
 			// https://github.com/kulshekhar/ts-jest/issues/1057#issuecomment-1482644543:
-			"^(\\.\\.?\\/.+)\\.(cjs|js|jsx)": "$1",
+			"^(\\.\\.?\\/.+)\\.(js|jsx)": "$1",
 		},
 		// Note that while `rootDir` is set to an absolute path here, Jest also knows how to interpret relative paths.
 		// For example, a consuming repo depending on `devdeps` could use "../../../../" as the path to traverse


### PR DESCRIPTION
- The https://github.com/dustin-ruetz/devdeps/pull/52 PR upgraded ESLint from v8 to v9. This meant that the ESLint configuration file went from v8's `module.exports` CommonJS syntax to v9's `export default` ES Module (ESM) syntax.
- The ESLint v8 configuration file was the last remaining part of the codebase that required the CommonJS/CommonTS syntax, so this PR removes the `.cjs`/`.cts`-related code.
- This PR is related to the https://github.com/dustin-ruetz/devdeps/pull/24 PR, but essentially it goes in the opposite direction, since having Jest transform `.cjs`/`.cts` files is no longer needed due to this repo now being a fully-ESM codebase.